### PR TITLE
fix: use GHCR as primary registry to avoid Docker Hub rate limits

### DIFF
--- a/.github/workflows/docker-build-matrix.yml
+++ b/.github/workflows/docker-build-matrix.yml
@@ -65,7 +65,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           cache-from: type=gha,scope=${{ steps.prep.outputs.cache-key }}
           cache-to: type=gha,mode=max,scope=${{ steps.prep.outputs.cache-key }}
-          outputs: type=image,name=${{ env.DOCKER_HUB_REPO }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.GITHUB_PACKAGES_REPO }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -109,21 +109,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create manifest list and push to Docker Hub
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ env.DOCKER_HUB_REPO }}:${{ env.VERSION }} \
-            $(printf '${{ env.DOCKER_HUB_REPO }}@sha256:%s ' *)
-
       - name: Create manifest list and push to GitHub Packages
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
             --tag ${{ env.GITHUB_PACKAGES_REPO }}:${{ env.VERSION }} \
-            $(printf '${{ env.DOCKER_HUB_REPO }}@sha256:%s ' *)
+            $(printf '${{ env.GITHUB_PACKAGES_REPO }}@sha256:%s ' *)
+
+      - name: Create manifest list and push to Docker Hub
+        working-directory: /tmp/digests
+        continue-on-error: true  # Don't fail if Docker Hub has rate limits
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.DOCKER_HUB_REPO }}:${{ env.VERSION }} \
+            $(printf '${{ env.GITHUB_PACKAGES_REPO }}@sha256:%s ' *)
 
       - name: Inspect images
         run: |
-          docker buildx imagetools inspect ${{ env.DOCKER_HUB_REPO }}:${{ env.VERSION }}
           docker buildx imagetools inspect ${{ env.GITHUB_PACKAGES_REPO }}:${{ env.VERSION }}
+          docker buildx imagetools inspect ${{ env.DOCKER_HUB_REPO }}:${{ env.VERSION }} || echo "Docker Hub image not available"

--- a/.github/workflows/package-from-docker.yml
+++ b/.github/workflows/package-from-docker.yml
@@ -26,7 +26,7 @@ on:
       - '.github/workflows/package-from-docker.yml'
 
 env:
-  DOCKER_IMAGE: gounthar/openscad
+  DOCKER_IMAGE: ghcr.io/gounthar/openscad
   PACKAGE_VERSION: 2024.11.18
   PACKAGE_REVISION: 1
 


### PR DESCRIPTION
## Summary
- Build and push images to ghcr.io first (primary registry)
- Docker Hub push now has `continue-on-error: true` for rate limit resilience
- Package workflow now pulls from `ghcr.io/gounthar/openscad`

## Problem
Docker Hub rate limits caused workflow failure:
```
429 Too Many Requests
toomanyrequests: You have reached your pull rate limit
```

## Solution
Use GitHub Container Registry (ghcr.io) as the primary registry since it has higher limits for GitHub Actions workflows.

## Test plan
- [ ] Docker build workflow completes successfully
- [ ] Images available at ghcr.io/gounthar/openscad
- [ ] Package workflow can pull from GHCR
- [ ] Docker Hub push gracefully handles rate limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)