### PR TITLE
feat: add release management and APT repository workflows

### DIFF
--- a/.github/workflows/cleanup-releases.yml
+++ b/.github/workflows/cleanup-releases.yml
@@ -1,0 +1,114 @@
+name: Cleanup Old Releases
+
+on:
+  schedule:
+    # Run weekly on Sundays at midnight UTC
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Delete releases older than N days'
+        type: number
+        default: 30
+      dry_run:
+        description: 'Dry run (list but do not delete)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    name: Delete Old Releases
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine retention period
+        id: config
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            DAYS="${{ inputs.days }}"
+            DRY_RUN="${{ inputs.dry_run }}"
+          else
+            DAYS="30"
+            DRY_RUN="false"
+          fi
+          echo "days=${DAYS}" >> $GITHUB_OUTPUT
+          echo "dry_run=${DRY_RUN}" >> $GITHUB_OUTPUT
+          echo "cutoff_date=$(date -d "${DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      - name: List releases to delete
+        id: list
+        run: |
+          CUTOFF="${{ steps.config.outputs.cutoff_date }}"
+          echo "Looking for releases older than ${CUTOFF}..."
+
+          # Get all releases and filter by date
+          RELEASES=$(gh release list --json tagName,publishedAt,isPrerelease \
+            --jq ".[] | select(.publishedAt < \"${CUTOFF}\") | .tagName")
+
+          if [ -z "$RELEASES" ]; then
+            echo "No releases found older than ${{ steps.config.outputs.days }} days."
+            echo "count=0" >> $GITHUB_OUTPUT
+          else
+            echo "Releases to delete:"
+            echo "$RELEASES"
+            echo "releases<<EOF" >> $GITHUB_OUTPUT
+            echo "$RELEASES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            COUNT=$(echo "$RELEASES" | wc -l)
+            echo "count=${COUNT}" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Delete old releases
+        if: steps.list.outputs.count != '0' && steps.config.outputs.dry_run == 'false'
+        run: |
+          echo "Deleting ${{ steps.list.outputs.count }} releases..."
+
+          echo "${{ steps.list.outputs.releases }}" | while read tag; do
+            if [ -n "$tag" ]; then
+              echo "Deleting release: ${tag}"
+              gh release delete "${tag}" --yes --cleanup-tag
+            fi
+          done
+
+          echo "Cleanup complete!"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Dry run summary
+        if: steps.list.outputs.count != '0' && steps.config.outputs.dry_run == 'true'
+        run: |
+          echo "DRY RUN - Would delete the following releases:"
+          echo "${{ steps.list.outputs.releases }}"
+
+      - name: Summary
+        run: |
+          echo "## Release Cleanup Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Retention period:** ${{ steps.config.outputs.days }} days" >> $GITHUB_STEP_SUMMARY
+          echo "**Cutoff date:** ${{ steps.config.outputs.cutoff_date }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Dry run:** ${{ steps.config.outputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ steps.list.outputs.count }}" = "0" ]; then
+            echo "No releases older than ${{ steps.config.outputs.days }} days found." >> $GITHUB_STEP_SUMMARY
+          else
+            if [ "${{ steps.config.outputs.dry_run }}" = "true" ]; then
+              echo "### Releases to be deleted" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "### Releases deleted" >> $GITHUB_STEP_SUMMARY
+            fi
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "${{ steps.list.outputs.releases }}" | while read tag; do
+              if [ -n "$tag" ]; then
+                echo "- ${tag}" >> $GITHUB_STEP_SUMMARY
+              fi
+            done
+          fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,199 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 2024.11.18)'
+        type: string
+        required: true
+      prerelease:
+        description: 'Mark as pre-release'
+        type: boolean
+        default: true
+      run_id:
+        description: 'Workflow run ID to download artifacts from (leave empty for latest)'
+        type: string
+        required: false
+  workflow_run:
+    workflows: ["Package from Docker Image"]
+    types:
+      - completed
+    branches:
+      - multiplatform
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # Use date-based version for automatic releases
+            VERSION=$(date +%Y.%m.%d)
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Determine workflow run ID
+        id: run
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ -n "${{ inputs.run_id }}" ]; then
+              echo "run_id=${{ inputs.run_id }}" >> $GITHUB_OUTPUT
+            else
+              # Get the latest successful packaging workflow run
+              RUN_ID=$(gh run list --workflow=package-from-docker.yml --status=success --limit=1 --json databaseId --jq '.[0].databaseId')
+              echo "run_id=${RUN_ID}" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Download artifacts from packaging workflow
+        run: |
+          mkdir -p packages
+
+          echo "Downloading artifacts from run ${{ steps.run.outputs.run_id }}..."
+
+          # Download all artifacts from the packaging workflow
+          gh run download ${{ steps.run.outputs.run_id }} --dir packages
+
+          # List downloaded files
+          echo "Downloaded packages:"
+          find packages -name "*.deb" -type f
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Prepare release assets
+        id: assets
+        run: |
+          mkdir -p release-assets
+
+          # Move all .deb files to release-assets with flat structure
+          find packages -name "*.deb" -exec cp {} release-assets/ \;
+
+          # List assets
+          echo "Release assets:"
+          ls -lh release-assets/
+
+          # Count packages
+          if ls release-assets/*.deb 1>/dev/null 2>&1; then
+            COUNT=$(ls release-assets/*.deb | wc -l)
+          else
+            COUNT=0
+            echo "Warning: No .deb files found in release-assets"
+          fi
+          echo "count=${COUNT}" >> $GITHUB_OUTPUT
+
+      - name: Check if release already exists
+        id: check
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" &>/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Delete existing release if needed
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          echo "Deleting existing release ${{ steps.version.outputs.tag }}..."
+          gh release delete "${{ steps.version.outputs.tag }}" --yes --cleanup-tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Create GitHub Release
+        run: |
+          # Determine if prerelease
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PRERELEASE="${{ inputs.prerelease }}"
+          else
+            PRERELEASE="true"
+          fi
+
+          # Build release notes
+          cat > release-notes.md << 'EOF'
+          ## OpenSCAD Multi-Architecture Packages
+
+          Pre-built Debian packages for multiple architectures, extracted from Docker images.
+
+          ### Supported Architectures
+          - **amd64** (x86_64)
+          - **arm64** (aarch64)
+          - **riscv64**
+
+          ### Installation
+
+          ```bash
+          # Download the appropriate .deb for your architecture
+          sudo dpkg -i openscad_${{ steps.version.outputs.version }}-1_<arch>.deb
+
+          # Install any missing dependencies
+          sudo apt-get install -f
+          ```
+
+          ### Docker Images
+
+          Docker images are also available:
+          ```bash
+          docker pull ghcr.io/gounthar/openscad:latest
+          ```
+
+          ### Build Information
+          - Built from commit: ${{ github.sha }}
+          - Workflow run: ${{ steps.run.outputs.run_id }}
+          EOF
+
+          # Create release with assets
+          if [ "${PRERELEASE}" = "true" ]; then
+            gh release create "${{ steps.version.outputs.tag }}" \
+              --title "OpenSCAD ${{ steps.version.outputs.version }}" \
+              --notes-file release-notes.md \
+              --prerelease \
+              release-assets/*.deb
+          else
+            gh release create "${{ steps.version.outputs.tag }}" \
+              --title "OpenSCAD ${{ steps.version.outputs.version }}" \
+              --notes-file release-notes.md \
+              release-assets/*.deb
+          fi
+
+          echo "Release created: ${{ steps.version.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Summary
+        run: |
+          echo "## Release Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** ${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Packages:** ${{ steps.assets.outputs.count }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Assets" >> $GITHUB_STEP_SUMMARY
+          if ls release-assets/*.deb 1>/dev/null 2>&1; then
+            ls release-assets/*.deb | while read pkg; do
+              name=$(basename "$pkg")
+              size=$(du -h "$pkg" | cut -f1)
+              echo "- **${name}** (${size})" >> $GITHUB_STEP_SUMMARY
+            done
+          else
+            echo "No packages found" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -1,0 +1,274 @@
+name: Update APT Repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Workflow run ID to get packages from (leave empty for latest)'
+        type: string
+        required: false
+  workflow_run:
+    workflows: ["Package from Docker Image"]
+    types:
+      - completed
+    branches:
+      - multiplatform
+
+permissions:
+  contents: write
+
+env:
+  SUITE: stable
+  COMPONENT: main
+  ORIGIN: gounthar
+  LABEL: OpenSCAD Multi-Arch
+  GPG_KEY_ID: '56188341425B007407229B48FB1963FC3575A39D'
+  GPG_PUBLIC_KEY_URL: 'https://github.com/gounthar/docker-for-riscv64/releases/download/gpg-key/gpg-public-key.asc'
+
+jobs:
+  update-repo:
+    name: Update Debian Repository
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Install APT tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev apt-utils gnupg
+
+      - name: Import GPG key for signing
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          if [ -z "$GPG_PRIVATE_KEY" ]; then
+            echo "Warning: GPG_PRIVATE_KEY secret not set, repository will not be signed"
+            echo "signed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Importing GPG key for package signing..."
+            echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+            gpg --list-secret-keys
+            echo "GPG key imported successfully"
+            echo "signed=true" >> $GITHUB_OUTPUT
+          fi
+        id: gpg
+
+      - name: Determine workflow run ID
+        id: run
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ -n "${{ inputs.run_id }}" ]; then
+              echo "run_id=${{ inputs.run_id }}" >> $GITHUB_OUTPUT
+            else
+              RUN_ID=$(gh run list --workflow=package-from-docker.yml --status=success --limit=1 --json databaseId --jq '.[0].databaseId')
+              echo "run_id=${RUN_ID}" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Download packages from workflow
+        run: |
+          mkdir -p downloads
+          echo "Downloading artifacts from run ${{ steps.run.outputs.run_id }}..."
+          gh run download ${{ steps.run.outputs.run_id }} --dir downloads
+          echo "Downloaded packages:"
+          find downloads -name "*.deb" -type f
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Setup repository structure
+        run: |
+          # Create pool directory for all .deb files
+          mkdir -p pool/${{ env.COMPONENT }}
+
+          # Copy all .deb files to pool
+          find downloads -name "*.deb" -exec cp {} pool/${{ env.COMPONENT }}/ \;
+
+          # List packages in pool
+          echo "Packages in pool:"
+          ls -lh pool/${{ env.COMPONENT }}/
+
+      - name: Generate Packages files for each architecture
+        run: |
+          # Get list of architectures from package names
+          ARCHS=$(ls pool/${{ env.COMPONENT }}/*.deb | sed -n 's/.*_\([^_]*\)\.deb$/\1/p' | sort -u)
+
+          echo "Architectures found: $ARCHS"
+
+          for ARCH in $ARCHS; do
+            echo "Processing architecture: $ARCH"
+
+            # Create directory structure
+            DIST_DIR="dists/${{ env.SUITE }}/${{ env.COMPONENT }}/binary-${ARCH}"
+            mkdir -p "${DIST_DIR}"
+
+            # Generate Packages file
+            dpkg-scanpackages --arch ${ARCH} pool/${{ env.COMPONENT }} > "${DIST_DIR}/Packages"
+
+            # Generate compressed versions
+            gzip -k -f "${DIST_DIR}/Packages"
+            xz -k -f "${DIST_DIR}/Packages"
+
+            # Show package count
+            PKG_COUNT=$(grep -c "^Package:" "${DIST_DIR}/Packages" || echo 0)
+            echo "  ${PKG_COUNT} packages for ${ARCH}"
+          done
+
+      - name: Generate Release file
+        run: |
+          DIST_DIR="dists/${{ env.SUITE }}"
+
+          # Get architectures
+          ARCHS=$(ls ${DIST_DIR}/${{ env.COMPONENT }}/ | sed 's/binary-//' | tr '\n' ' ')
+
+          # Create Release file
+          cat > "${DIST_DIR}/Release" << EOF
+          Origin: ${{ env.ORIGIN }}
+          Label: ${{ env.LABEL }}
+          Suite: ${{ env.SUITE }}
+          Codename: ${{ env.SUITE }}
+          Version: $(date +%Y.%m.%d)
+          Architectures: ${ARCHS}
+          Components: ${{ env.COMPONENT }}
+          Description: OpenSCAD packages for multiple architectures
+          Date: $(date -Ru)
+          EOF
+
+          # Add checksums
+          echo "MD5Sum:" >> "${DIST_DIR}/Release"
+          find "${DIST_DIR}/${{ env.COMPONENT }}" -type f | while read file; do
+            SIZE=$(stat -c %s "$file")
+            MD5=$(md5sum "$file" | cut -d' ' -f1)
+            RELPATH=${file#${DIST_DIR}/}
+            printf " %s %16d %s\n" "$MD5" "$SIZE" "$RELPATH" >> "${DIST_DIR}/Release"
+          done
+
+          echo "SHA256:" >> "${DIST_DIR}/Release"
+          find "${DIST_DIR}/${{ env.COMPONENT }}" -type f | while read file; do
+            SIZE=$(stat -c %s "$file")
+            SHA256=$(sha256sum "$file" | cut -d' ' -f1)
+            RELPATH=${file#${DIST_DIR}/}
+            printf " %s %16d %s\n" "$SHA256" "$SIZE" "$RELPATH" >> "${DIST_DIR}/Release"
+          done
+
+          echo "Release file created:"
+          cat "${DIST_DIR}/Release"
+
+      - name: Sign Release file
+        if: steps.gpg.outputs.signed == 'true'
+        run: |
+          DIST_DIR="dists/${{ env.SUITE }}"
+
+          # Create InRelease (clearsigned)
+          gpg --batch --yes --clearsign -o "${DIST_DIR}/InRelease" "${DIST_DIR}/Release"
+
+          # Create Release.gpg (detached signature)
+          gpg --batch --yes --armor --detach-sign -o "${DIST_DIR}/Release.gpg" "${DIST_DIR}/Release"
+
+          echo "Repository signed successfully"
+          ls -la "${DIST_DIR}/"
+
+      - name: Create index page
+        run: |
+          cat > index.html << 'EOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <title>OpenSCAD APT Repository</title>
+            <style>
+              body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 800px; margin: 50px auto; padding: 20px; }
+              h1 { color: #333; }
+              pre { background: #f4f4f4; padding: 15px; border-radius: 5px; overflow-x: auto; }
+              code { background: #f4f4f4; padding: 2px 5px; border-radius: 3px; }
+              .warning { background: #fff3cd; border: 1px solid #ffc107; padding: 10px; border-radius: 5px; margin: 10px 0; }
+            </style>
+          </head>
+          <body>
+            <h1>OpenSCAD APT Repository</h1>
+            <p>Multi-architecture Debian packages for OpenSCAD.</p>
+
+            <h2>Supported Architectures</h2>
+            <ul>
+              <li><strong>amd64</strong> (x86_64)</li>
+              <li><strong>arm64</strong> (aarch64)</li>
+              <li><strong>riscv64</strong></li>
+            </ul>
+
+            <h2>Installation</h2>
+
+            <h3>1. Import the GPG key</h3>
+            <pre>curl -fsSL ${{ env.GPG_PUBLIC_KEY_URL }} | sudo gpg --dearmor -o /usr/share/keyrings/openscad-archive-keyring.gpg</pre>
+
+            <h3>2. Add the repository</h3>
+            <pre>echo "deb [signed-by=/usr/share/keyrings/openscad-archive-keyring.gpg] https://gounthar.github.io/openscad stable main" | sudo tee /etc/apt/sources.list.d/openscad.list</pre>
+
+            <h3>3. Update and install</h3>
+            <pre>sudo apt-get update
+          sudo apt-get install openscad</pre>
+
+            <h2>Direct Download</h2>
+            <p>You can also download packages directly from <a href="https://github.com/gounthar/openscad/releases">GitHub Releases</a>.</p>
+
+            <h2>Docker Images</h2>
+            <pre>docker pull ghcr.io/gounthar/openscad:latest</pre>
+
+            <hr>
+            <p><small>Generated by <a href="https://github.com/gounthar/openscad">gounthar/openscad</a></small></p>
+          </body>
+          </html>
+          EOF
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          git status
+
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update APT repository with latest packages"
+            git push origin gh-pages
+          fi
+
+      - name: Summary
+        run: |
+          echo "## APT Repository Updated" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Repository URL:** https://gounthar.github.io/openscad" >> $GITHUB_STEP_SUMMARY
+          echo "**GPG Signed:** ${{ steps.gpg.outputs.signed }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Installation" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo '# Import GPG key' >> $GITHUB_STEP_SUMMARY
+          echo 'curl -fsSL ${{ env.GPG_PUBLIC_KEY_URL }} | sudo gpg --dearmor -o /usr/share/keyrings/openscad-archive-keyring.gpg' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '# Add repository' >> $GITHUB_STEP_SUMMARY
+          echo 'echo "deb [signed-by=/usr/share/keyrings/openscad-archive-keyring.gpg] https://gounthar.github.io/openscad stable main" | sudo tee /etc/apt/sources.list.d/openscad.list' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '# Install' >> $GITHUB_STEP_SUMMARY
+          echo 'sudo apt-get update' >> $GITHUB_STEP_SUMMARY
+          echo 'sudo apt-get install openscad' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Packages" >> $GITHUB_STEP_SUMMARY
+          if ls pool/${{ env.COMPONENT }}/*.deb 1>/dev/null 2>&1; then
+            ls pool/${{ env.COMPONENT }}/*.deb | while read pkg; do
+              name=$(basename "$pkg")
+              size=$(du -h "$pkg" | cut -f1)
+              echo "- **${name}** (${size})" >> $GITHUB_STEP_SUMMARY
+            done
+          else
+            echo "No packages found" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary

Three new workflows for package distribution:

### 1. create-release.yml
- Automatically creates GitHub Releases after packaging workflow completes
- Uploads .deb packages as release assets
- Supports manual trigger with custom version
- Can overwrite existing releases

### 2. cleanup-releases.yml
- Deletes releases older than 30 days (configurable)
- Runs weekly on Sunday at midnight UTC
- Supports dry-run mode to preview deletions

### 3. update-apt-repo.yml
- Creates Debian APT repository on gh-pages branch
- Generates Packages, Release files for each architecture
- Creates index.html with installation instructions
- Users can install via:
  ```bash
  echo "deb [trusted=yes] https://gounthar.github.io/openscad stable main" | sudo tee /etc/apt/sources.list.d/openscad.list
  sudo apt-get update
  sudo apt-get install openscad
  ```

## Prerequisites

- gh-pages branch needs to exist (workflow will push to it)
- GitHub Pages needs to be enabled for the repository

## Test plan

- [ ] Create a release manually with workflow_dispatch
- [ ] Verify .deb packages are uploaded as assets
- [ ] Test cleanup workflow in dry-run mode
- [ ] Enable gh-pages and test APT repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)