### PR TITLE
fix: add artifact checks to release workflows

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -64,7 +64,34 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Check if run has artifacts
+        id: check_artifacts
+        run: |
+          RUN_ID="${{ steps.run.outputs.run_id }}"
+          echo "Checking artifacts for run ${RUN_ID}..."
+
+          ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count')
+          echo "Found ${ARTIFACT_COUNT} artifacts"
+
+          if [ "${ARTIFACT_COUNT}" = "0" ]; then
+            echo "No artifacts found in run ${RUN_ID}. Skipping release creation."
+            echo "has_artifacts=false" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "has_artifacts=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Skip if no artifacts
+        if: steps.check_artifacts.outputs.has_artifacts == 'false'
+        run: |
+          echo "::notice::Skipping release creation - no artifacts found in packaging run"
+          echo "## Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "No artifacts found in packaging workflow run. This usually means all packaging jobs were skipped." >> $GITHUB_STEP_SUMMARY
+
       - name: Download artifacts from packaging workflow
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |
           mkdir -p packages
 
@@ -80,6 +107,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Prepare release assets
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         id: assets
         run: |
           mkdir -p release-assets
@@ -101,6 +129,7 @@ jobs:
           echo "count=${COUNT}" >> $GITHUB_OUTPUT
 
       - name: Check if release already exists
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         id: check
         run: |
           if gh release view "${{ steps.version.outputs.tag }}" &>/dev/null; then
@@ -112,7 +141,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Delete existing release if needed
-        if: steps.check.outputs.exists == 'true'
+        if: steps.check_artifacts.outputs.has_artifacts == 'true' && steps.check.outputs.exists == 'true'
         run: |
           echo "Deleting existing release ${{ steps.version.outputs.tag }}..."
           gh release delete "${{ steps.version.outputs.tag }}" --yes --cleanup-tag
@@ -120,6 +149,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create GitHub Release
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |
           # Determine if prerelease
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -180,6 +210,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Summary
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |
           echo "## Release Created" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -73,6 +73,7 @@ jobs:
           ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count' 2>/dev/null || echo "")
 
           if [ -z "${ARTIFACT_COUNT}" ]; then
+            echo "has_artifacts=false" >> $GITHUB_OUTPUT
             echo "Error: Failed to retrieve artifact count for run ${RUN_ID}"
             exit 1
           fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -70,7 +70,13 @@ jobs:
           RUN_ID="${{ steps.run.outputs.run_id }}"
           echo "Checking artifacts for run ${RUN_ID}..."
 
-          ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count')
+          ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count' 2>/dev/null || echo "")
+
+          if [ -z "${ARTIFACT_COUNT}" ]; then
+            echo "Error: Failed to retrieve artifact count for run ${RUN_ID}"
+            exit 1
+          fi
+
           echo "Found ${ARTIFACT_COUNT} artifacts"
 
           if [ "${ARTIFACT_COUNT}" = "0" ]; then

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -73,7 +73,6 @@ jobs:
           ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count' 2>/dev/null || echo "")
 
           if [ -z "${ARTIFACT_COUNT}" ]; then
-            echo "has_artifacts=false" >> $GITHUB_OUTPUT
             echo "Error: Failed to retrieve artifact count for run ${RUN_ID}"
             exit 1
           fi

--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -84,6 +84,7 @@ jobs:
           ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count' 2>/dev/null || echo "")
 
           if [ -z "${ARTIFACT_COUNT}" ]; then
+            echo "has_artifacts=false" >> $GITHUB_OUTPUT
             echo "Error: Failed to retrieve artifact count for run ${RUN_ID}"
             exit 1
           fi

--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -81,7 +81,13 @@ jobs:
           RUN_ID="${{ steps.run.outputs.run_id }}"
           echo "Checking artifacts for run ${RUN_ID}..."
 
-          ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count')
+          ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count' 2>/dev/null || echo "")
+
+          if [ -z "${ARTIFACT_COUNT}" ]; then
+            echo "Error: Failed to retrieve artifact count for run ${RUN_ID}"
+            exit 1
+          fi
+
           echo "Found ${ARTIFACT_COUNT} artifacts"
 
           if [ "${ARTIFACT_COUNT}" = "0" ]; then

--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -84,7 +84,6 @@ jobs:
           ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count' 2>/dev/null || echo "")
 
           if [ -z "${ARTIFACT_COUNT}" ]; then
-            echo "has_artifacts=false" >> $GITHUB_OUTPUT
             echo "Error: Failed to retrieve artifact count for run ${RUN_ID}"
             exit 1
           fi

--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -75,7 +75,34 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Check if run has artifacts
+        id: check_artifacts
+        run: |
+          RUN_ID="${{ steps.run.outputs.run_id }}"
+          echo "Checking artifacts for run ${RUN_ID}..."
+
+          ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count')
+          echo "Found ${ARTIFACT_COUNT} artifacts"
+
+          if [ "${ARTIFACT_COUNT}" = "0" ]; then
+            echo "No artifacts found in run ${RUN_ID}. Skipping repository update."
+            echo "has_artifacts=false" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "has_artifacts=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Skip if no artifacts
+        if: steps.check_artifacts.outputs.has_artifacts == 'false'
+        run: |
+          echo "::notice::Skipping APT repository update - no artifacts found in packaging run"
+          echo "## Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "No artifacts found in packaging workflow run. This usually means all packaging jobs were skipped." >> $GITHUB_STEP_SUMMARY
+
       - name: Download packages from workflow
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |
           mkdir -p downloads
           echo "Downloading artifacts from run ${{ steps.run.outputs.run_id }}..."
@@ -86,6 +113,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Setup repository structure
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |
           # Create pool directory for all .deb files
           mkdir -p pool/${{ env.COMPONENT }}
@@ -98,6 +126,7 @@ jobs:
           ls -lh pool/${{ env.COMPONENT }}/
 
       - name: Generate Packages files for each architecture
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |
           # Get list of architectures from package names
           ARCHS=$(ls pool/${{ env.COMPONENT }}/*.deb | sed -n 's/.*_\([^_]*\)\.deb$/\1/p' | sort -u)
@@ -130,6 +159,7 @@ jobs:
           done
 
       - name: Generate Release file
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |
           DIST_DIR="dists/${{ env.SUITE }}"
 
@@ -170,7 +200,7 @@ jobs:
           cat "${DIST_DIR}/Release"
 
       - name: Sign Release file
-        if: steps.gpg.outputs.signed == 'true'
+        if: steps.check_artifacts.outputs.has_artifacts == 'true' && steps.gpg.outputs.signed == 'true'
         run: |
           DIST_DIR="dists/${{ env.SUITE }}"
 
@@ -184,6 +214,7 @@ jobs:
           ls -la "${DIST_DIR}/"
 
       - name: Create index page
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |
           cat > index.html << 'EOF'
           <!DOCTYPE html>
@@ -234,6 +265,7 @@ jobs:
           EOF
 
       - name: Commit and push changes
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -249,6 +281,7 @@ jobs:
           fi
 
       - name: Summary
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |
           echo "## APT Repository Updated" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Add artifact validation to `create-release.yml` and `update-apt-repo.yml`
- Workflows now check if the triggering packaging run has artifacts before downloading
- Gracefully skip with notice and summary when no artifacts exist

This prevents the workflow failures seen in runs:
- https://github.com/gounthar/openscad/actions/runs/19469993277
- https://github.com/gounthar/openscad/actions/runs/19469993280

## Test plan
- [ ] Manually trigger create-release.yml with a run ID that has artifacts - should create release
- [ ] Auto-trigger from a packaging run with no artifacts - should skip gracefully
- [ ] Verify summary shows appropriate message for both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release and repository-update workflows now detect whether packaging produced artifacts before proceeding.
  * When no artifacts exist, downstream steps (download, asset preparation, signing, release creation, index/update, commit) are skipped and emit clear skip notices and summary entries.
  * Conditional guards added to prevent unnecessary or partial release actions, reducing risk of empty/incomplete releases and improving reliability and traceability of automated releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->