### PR TITLE
refactor: extract artifact-checking into composite action

### DIFF
--- a/.github/actions/check-run-artifacts/action.yml
+++ b/.github/actions/check-run-artifacts/action.yml
@@ -24,21 +24,22 @@ runs:
       id: check
       shell: bash
       run: |
-        RUN_ID="${{ inputs.run_id }}"
-        echo "Checking artifacts for run ${RUN_ID}..."
+        set -eo pipefail
 
-        ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count' 2>/dev/null || echo "")
+        echo "Checking artifacts for run ${{ inputs.run_id }}..."
 
-        if [ -z "${ARTIFACT_COUNT}" ]; then
-          echo "Error: Failed to retrieve artifact count for run ${RUN_ID}"
+        ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${{ inputs.run_id }}/artifacts --jq '.total_count')
+
+        if [[ "${ARTIFACT_COUNT}" == "null" ]]; then
+          echo "Error: Failed to retrieve a valid artifact count from API response for run ${{ inputs.run_id }}." >&2
           exit 1
         fi
 
         echo "Found ${ARTIFACT_COUNT} artifacts"
         echo "artifact_count=${ARTIFACT_COUNT}" >> $GITHUB_OUTPUT
 
-        if [ "${ARTIFACT_COUNT}" = "0" ]; then
-          echo "No artifacts found in run ${RUN_ID}."
+        if [ "${ARTIFACT_COUNT}" -eq 0 ]; then
+          echo "No artifacts found in run ${{ inputs.run_id }}."
           echo "has_artifacts=false" >> $GITHUB_OUTPUT
         else
           echo "has_artifacts=true" >> $GITHUB_OUTPUT
@@ -50,6 +51,6 @@ runs:
       if: steps.check.outputs.has_artifacts == 'false'
       shell: bash
       run: |
-        echo "::notice::No artifacts found in packaging run ${{ inputs.run_id }}"
+        echo "::notice::No artifacts found in workflow run ${{ inputs.run_id }}"
         echo "## Skipped" >> $GITHUB_STEP_SUMMARY
-        echo "No artifacts found in packaging workflow run. This usually means all packaging jobs were skipped." >> $GITHUB_STEP_SUMMARY
+        echo "No artifacts found in workflow run ${{ inputs.run_id }}. Subsequent steps may be skipped." >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/check-run-artifacts/action.yml
+++ b/.github/actions/check-run-artifacts/action.yml
@@ -1,0 +1,55 @@
+name: 'Check Run Artifacts'
+description: 'Check if a workflow run has artifacts before downloading'
+
+inputs:
+  run_id:
+    description: 'The workflow run ID to check for artifacts'
+    required: true
+  github_token:
+    description: 'GitHub token for API access'
+    required: true
+
+outputs:
+  has_artifacts:
+    description: 'Whether the run has artifacts (true/false)'
+    value: ${{ steps.check.outputs.has_artifacts }}
+  artifact_count:
+    description: 'Number of artifacts in the run'
+    value: ${{ steps.check.outputs.artifact_count }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check if run has artifacts
+      id: check
+      shell: bash
+      run: |
+        RUN_ID="${{ inputs.run_id }}"
+        echo "Checking artifacts for run ${RUN_ID}..."
+
+        ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count' 2>/dev/null || echo "")
+
+        if [ -z "${ARTIFACT_COUNT}" ]; then
+          echo "Error: Failed to retrieve artifact count for run ${RUN_ID}"
+          exit 1
+        fi
+
+        echo "Found ${ARTIFACT_COUNT} artifacts"
+        echo "artifact_count=${ARTIFACT_COUNT}" >> $GITHUB_OUTPUT
+
+        if [ "${ARTIFACT_COUNT}" = "0" ]; then
+          echo "No artifacts found in run ${RUN_ID}."
+          echo "has_artifacts=false" >> $GITHUB_OUTPUT
+        else
+          echo "has_artifacts=true" >> $GITHUB_OUTPUT
+        fi
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+
+    - name: Show skip notice if no artifacts
+      if: steps.check.outputs.has_artifacts == 'false'
+      shell: bash
+      run: |
+        echo "::notice::No artifacts found in packaging run ${{ inputs.run_id }}"
+        echo "## Skipped" >> $GITHUB_STEP_SUMMARY
+        echo "No artifacts found in packaging workflow run. This usually means all packaging jobs were skipped." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -66,35 +66,10 @@ jobs:
 
       - name: Check if run has artifacts
         id: check_artifacts
-        run: |
-          RUN_ID="${{ steps.run.outputs.run_id }}"
-          echo "Checking artifacts for run ${RUN_ID}..."
-
-          ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count' 2>/dev/null || echo "")
-
-          if [ -z "${ARTIFACT_COUNT}" ]; then
-            echo "Error: Failed to retrieve artifact count for run ${RUN_ID}"
-            exit 1
-          fi
-
-          echo "Found ${ARTIFACT_COUNT} artifacts"
-
-          if [ "${ARTIFACT_COUNT}" = "0" ]; then
-            echo "No artifacts found in run ${RUN_ID}. Skipping release creation."
-            echo "has_artifacts=false" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "has_artifacts=true" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Skip if no artifacts
-        if: steps.check_artifacts.outputs.has_artifacts == 'false'
-        run: |
-          echo "::notice::Skipping release creation - no artifacts found in packaging run"
-          echo "## Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "No artifacts found in packaging workflow run. This usually means all packaging jobs were skipped." >> $GITHUB_STEP_SUMMARY
+        uses: ./.github/actions/check-run-artifacts
+        with:
+          run_id: ${{ steps.run.outputs.run_id }}
+          github_token: ${{ github.token }}
 
       - name: Download artifacts from packaging workflow
         if: steps.check_artifacts.outputs.has_artifacts == 'true'

--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -77,35 +77,10 @@ jobs:
 
       - name: Check if run has artifacts
         id: check_artifacts
-        run: |
-          RUN_ID="${{ steps.run.outputs.run_id }}"
-          echo "Checking artifacts for run ${RUN_ID}..."
-
-          ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts --jq '.total_count' 2>/dev/null || echo "")
-
-          if [ -z "${ARTIFACT_COUNT}" ]; then
-            echo "Error: Failed to retrieve artifact count for run ${RUN_ID}"
-            exit 1
-          fi
-
-          echo "Found ${ARTIFACT_COUNT} artifacts"
-
-          if [ "${ARTIFACT_COUNT}" = "0" ]; then
-            echo "No artifacts found in run ${RUN_ID}. Skipping repository update."
-            echo "has_artifacts=false" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "has_artifacts=true" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Skip if no artifacts
-        if: steps.check_artifacts.outputs.has_artifacts == 'false'
-        run: |
-          echo "::notice::Skipping APT repository update - no artifacts found in packaging run"
-          echo "## Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "No artifacts found in packaging workflow run. This usually means all packaging jobs were skipped." >> $GITHUB_STEP_SUMMARY
+        uses: ./.github/actions/check-run-artifacts
+        with:
+          run_id: ${{ steps.run.outputs.run_id }}
+          github_token: ${{ github.token }}
 
       - name: Download packages from workflow
         if: steps.check_artifacts.outputs.has_artifacts == 'true'


### PR DESCRIPTION
## Summary

- Create reusable composite action at `.github/actions/check-run-artifacts/action.yml`
- Update `create-release.yml` to use the composite action
- Update `update-apt-repo.yml` to use the composite action

This centralizes the artifact validation logic, reducing code duplication from ~60 lines to ~12 lines across both workflows and ensuring consistent behavior.

## Composite Action Features

- **Inputs**: `run_id`, `github_token`
- **Outputs**: `has_artifacts` (true/false), `artifact_count`
- Handles API errors gracefully
- Shows skip notice in job summary when no artifacts found

## Test plan

- [ ] Manually trigger create-release.yml with a run ID that has artifacts
- [ ] Manually trigger update-apt-repo.yml with a run ID that has artifacts
- [ ] Verify skip behavior when triggered from packaging run with no artifacts

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced inline artifact-check logic with a reusable check to determine presence of workflow artifacts.
  * Standardized artifact gating for downstream release and update steps so behavior is consistent while preserving existing flow.
  * Improved maintainability and clarity of release/update workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->