### PR TITLE
feat: add RPM package creation for Fedora/RHEL

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ on:
         type: string
         required: false
   workflow_run:
-    workflows: ["Package from Docker Image"]
+    workflows: ["Package from Docker Image", "Package RPM from Docker Image"]
     types:
       - completed
     branches:
@@ -83,7 +83,7 @@ jobs:
 
           # List downloaded files
           echo "Downloaded packages:"
-          find packages -name "*.deb" -type f
+          find packages -name "*.deb" -o -name "*.rpm" -type f
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -93,21 +93,30 @@ jobs:
         run: |
           mkdir -p release-assets
 
-          # Move all .deb files to release-assets with flat structure
+          # Move all .deb and .rpm files to release-assets with flat structure
           find packages -name "*.deb" -exec cp {} release-assets/ \;
+          find packages -name "*.rpm" -exec cp {} release-assets/ \;
 
           # List assets
           echo "Release assets:"
           ls -lh release-assets/
 
           # Count packages
+          DEB_COUNT=0
+          RPM_COUNT=0
           if ls release-assets/*.deb 1>/dev/null 2>&1; then
-            COUNT=$(ls release-assets/*.deb | wc -l)
-          else
-            COUNT=0
-            echo "Warning: No .deb files found in release-assets"
+            DEB_COUNT=$(ls release-assets/*.deb | wc -l)
+          fi
+          if ls release-assets/*.rpm 1>/dev/null 2>&1; then
+            RPM_COUNT=$(ls release-assets/*.rpm | wc -l)
+          fi
+          COUNT=$((DEB_COUNT + RPM_COUNT))
+          if [ "$COUNT" -eq 0 ]; then
+            echo "Warning: No packages found in release-assets"
           fi
           echo "count=${COUNT}" >> $GITHUB_OUTPUT
+          echo "deb_count=${DEB_COUNT}" >> $GITHUB_OUTPUT
+          echo "rpm_count=${RPM_COUNT}" >> $GITHUB_OUTPUT
 
       - name: Check if release already exists
         if: steps.check_artifacts.outputs.has_artifacts == 'true'
@@ -153,12 +162,19 @@ jobs:
 
           ### Installation
 
+          ### Debian/Ubuntu Installation
           ```bash
           # Download the appropriate .deb for your architecture
           sudo dpkg -i openscad_${{ steps.version.outputs.version }}-1_<arch>.deb
 
           # Install any missing dependencies
           sudo apt-get install -f
+          ```
+
+          ### Fedora/RHEL Installation
+          ```bash
+          # Download the appropriate .rpm for your architecture
+          sudo dnf install openscad-${{ steps.version.outputs.version }}-1.<arch>.rpm
           ```
 
           ### Docker Images
@@ -173,18 +189,26 @@ jobs:
           - Workflow run: ${{ steps.run.outputs.run_id }}
           EOF
 
-          # Create release with assets
+          # Create release with assets (both .deb and .rpm)
+          ASSETS=""
+          if ls release-assets/*.deb 1>/dev/null 2>&1; then
+            ASSETS="$ASSETS release-assets/*.deb"
+          fi
+          if ls release-assets/*.rpm 1>/dev/null 2>&1; then
+            ASSETS="$ASSETS release-assets/*.rpm"
+          fi
+
           if [ "${PRERELEASE}" = "true" ]; then
             gh release create "${{ steps.version.outputs.tag }}" \
               --title "OpenSCAD ${{ steps.version.outputs.version }}" \
               --notes-file release-notes.md \
               --prerelease \
-              release-assets/*.deb
+              $ASSETS
           else
             gh release create "${{ steps.version.outputs.tag }}" \
               --title "OpenSCAD ${{ steps.version.outputs.version }}" \
               --notes-file release-notes.md \
-              release-assets/*.deb
+              $ASSETS
           fi
 
           echo "Release created: ${{ steps.version.outputs.tag }}"
@@ -202,11 +226,21 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Assets" >> $GITHUB_STEP_SUMMARY
           if ls release-assets/*.deb 1>/dev/null 2>&1; then
+            echo "#### Debian Packages" >> $GITHUB_STEP_SUMMARY
             ls release-assets/*.deb | while read pkg; do
               name=$(basename "$pkg")
               size=$(du -h "$pkg" | cut -f1)
               echo "- **${name}** (${size})" >> $GITHUB_STEP_SUMMARY
             done
-          else
+          fi
+          if ls release-assets/*.rpm 1>/dev/null 2>&1; then
+            echo "#### RPM Packages" >> $GITHUB_STEP_SUMMARY
+            ls release-assets/*.rpm | while read pkg; do
+              name=$(basename "$pkg")
+              size=$(du -h "$pkg" | cut -f1)
+              echo "- **${name}** (${size})" >> $GITHUB_STEP_SUMMARY
+            done
+          fi
+          if [ "${{ steps.assets.outputs.count }}" = "0" ]; then
             echo "No packages found" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/package-rpm-from-docker.yml
+++ b/.github/workflows/package-rpm-from-docker.yml
@@ -49,6 +49,20 @@ jobs:
           docker rm ${CONTAINER_ID}
 
           chmod +x extract/openscad
+
+          # Verify the binary was extracted
+          if [ ! -f extract/openscad ]; then
+            echo "Error: Failed to extract openscad binary"
+            exit 1
+          fi
+
+          # Log whether share directory was found
+          if [ -d extract/share ]; then
+            echo "Found share directory with data files"
+          else
+            echo "Warning: No share directory found - package will not include data files"
+          fi
+
           ls -la extract/
 
       - name: Set up RPM build tree
@@ -77,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rpm-amd64-docker
-          path: ~/rpmbuild/RPMS/x86_64/*.rpm
+          path: /home/runner/rpmbuild/RPMS/x86_64/*.rpm
           retention-days: 7
 
   package-rpm-arm64:
@@ -117,6 +131,20 @@ jobs:
           docker rm ${CONTAINER_ID}
 
           chmod +x extract/openscad
+
+          # Verify the binary was extracted
+          if [ ! -f extract/openscad ]; then
+            echo "Error: Failed to extract openscad binary"
+            exit 1
+          fi
+
+          # Log whether share directory was found
+          if [ -d extract/share ]; then
+            echo "Found share directory with data files"
+          else
+            echo "Warning: No share directory found - package will not include data files"
+          fi
+
           ls -la extract/
 
       - name: Set up RPM build tree
@@ -141,7 +169,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rpm-arm64-docker
-          path: ~/rpmbuild/RPMS/aarch64/*.rpm
+          path: /home/runner/rpmbuild/RPMS/aarch64/*.rpm
           retention-days: 7
 
   package-rpm-riscv64:
@@ -181,6 +209,20 @@ jobs:
           docker rm ${CONTAINER_ID}
 
           chmod +x extract/openscad
+
+          # Verify the binary was extracted
+          if [ ! -f extract/openscad ]; then
+            echo "Error: Failed to extract openscad binary"
+            exit 1
+          fi
+
+          # Log whether share directory was found
+          if [ -d extract/share ]; then
+            echo "Found share directory with data files"
+          else
+            echo "Warning: No share directory found - package will not include data files"
+          fi
+
           ls -la extract/
 
       - name: Set up RPM build tree
@@ -205,5 +247,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rpm-riscv64-docker
-          path: ~/rpmbuild/RPMS/riscv64/*.rpm
+          path: /home/runner/rpmbuild/RPMS/riscv64/*.rpm
           retention-days: 7

--- a/.github/workflows/package-rpm-from-docker.yml
+++ b/.github/workflows/package-rpm-from-docker.yml
@@ -1,0 +1,209 @@
+name: Package RPM from Docker Image
+
+on:
+  workflow_run:
+    workflows: ["Build and Push Docker Image (Multi-Platform)"]
+    types:
+      - completed
+    branches:
+      - multiplatform
+  workflow_dispatch:
+
+env:
+  DOCKER_IMAGE: ghcr.io/gounthar/openscad
+  PACKAGE_VERSION: 2025.11.19
+  PACKAGE_REVISION: 1
+
+jobs:
+  package-rpm-amd64:
+    name: Package RPM (amd64)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install RPM build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm rpmlint
+
+      - name: Set up Docker
+        run: |
+          docker --version
+          docker info
+
+      - name: Pull Docker image
+        run: |
+          docker pull --platform linux/amd64 ${{ env.DOCKER_IMAGE }}:latest
+
+      - name: Extract OpenSCAD binary and data
+        run: |
+          CONTAINER_ID=$(docker create --platform linux/amd64 ${{ env.DOCKER_IMAGE }}:latest)
+
+          mkdir -p extract
+          docker cp ${CONTAINER_ID}:/usr/local/bin/openscad extract/openscad
+          docker cp ${CONTAINER_ID}:/usr/local/share extract/share 2>/dev/null || true
+
+          docker rm ${CONTAINER_ID}
+
+          chmod +x extract/openscad
+          ls -la extract/
+
+      - name: Set up RPM build tree
+        run: |
+          mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+          # Copy binary and data to SOURCES
+          cp extract/openscad ~/rpmbuild/SOURCES/
+          cp -r extract/share ~/rpmbuild/SOURCES/ 2>/dev/null || true
+
+          # Copy spec file
+          cp rpm/openscad.spec ~/rpmbuild/SPECS/
+
+          # Update version in spec
+          sed -i "s/^Version:.*/Version:        ${{ env.PACKAGE_VERSION }}/" ~/rpmbuild/SPECS/openscad.spec
+
+      - name: Build RPM package
+        run: |
+          cd ~/rpmbuild/SPECS
+          rpmbuild -bb --target x86_64 openscad.spec
+
+          echo "Built RPM package:"
+          ls -lh ~/rpmbuild/RPMS/x86_64/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-amd64-docker
+          path: ~/rpmbuild/RPMS/x86_64/*.rpm
+          retention-days: 7
+
+  package-rpm-arm64:
+    name: Package RPM (arm64)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install RPM build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm rpmlint
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker
+        run: |
+          docker --version
+          docker info
+
+      - name: Pull Docker image
+        run: |
+          docker pull --platform linux/arm64 ${{ env.DOCKER_IMAGE }}:latest
+
+      - name: Extract OpenSCAD binary and data
+        run: |
+          CONTAINER_ID=$(docker create --platform linux/arm64 ${{ env.DOCKER_IMAGE }}:latest)
+
+          mkdir -p extract
+          docker cp ${CONTAINER_ID}:/usr/local/bin/openscad extract/openscad
+          docker cp ${CONTAINER_ID}:/usr/local/share extract/share 2>/dev/null || true
+
+          docker rm ${CONTAINER_ID}
+
+          chmod +x extract/openscad
+          ls -la extract/
+
+      - name: Set up RPM build tree
+        run: |
+          mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+          cp extract/openscad ~/rpmbuild/SOURCES/
+          cp -r extract/share ~/rpmbuild/SOURCES/ 2>/dev/null || true
+          cp rpm/openscad.spec ~/rpmbuild/SPECS/
+
+          sed -i "s/^Version:.*/Version:        ${{ env.PACKAGE_VERSION }}/" ~/rpmbuild/SPECS/openscad.spec
+
+      - name: Build RPM package
+        run: |
+          cd ~/rpmbuild/SPECS
+          rpmbuild -bb --target aarch64 openscad.spec
+
+          echo "Built RPM package:"
+          ls -lh ~/rpmbuild/RPMS/aarch64/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-arm64-docker
+          path: ~/rpmbuild/RPMS/aarch64/*.rpm
+          retention-days: 7
+
+  package-rpm-riscv64:
+    name: Package RPM (riscv64)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install RPM build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm rpmlint
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker
+        run: |
+          docker --version
+          docker info
+
+      - name: Pull Docker image
+        run: |
+          docker pull --platform linux/riscv64 ${{ env.DOCKER_IMAGE }}:latest
+
+      - name: Extract OpenSCAD binary and data
+        run: |
+          CONTAINER_ID=$(docker create --platform linux/riscv64 ${{ env.DOCKER_IMAGE }}:latest)
+
+          mkdir -p extract
+          docker cp ${CONTAINER_ID}:/usr/local/bin/openscad extract/openscad
+          docker cp ${CONTAINER_ID}:/usr/local/share extract/share 2>/dev/null || true
+
+          docker rm ${CONTAINER_ID}
+
+          chmod +x extract/openscad
+          ls -la extract/
+
+      - name: Set up RPM build tree
+        run: |
+          mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+          cp extract/openscad ~/rpmbuild/SOURCES/
+          cp -r extract/share ~/rpmbuild/SOURCES/ 2>/dev/null || true
+          cp rpm/openscad.spec ~/rpmbuild/SPECS/
+
+          sed -i "s/^Version:.*/Version:        ${{ env.PACKAGE_VERSION }}/" ~/rpmbuild/SPECS/openscad.spec
+
+      - name: Build RPM package
+        run: |
+          cd ~/rpmbuild/SPECS
+          rpmbuild -bb --target riscv64 openscad.spec
+
+          echo "Built RPM package:"
+          ls -lh ~/rpmbuild/RPMS/riscv64/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-riscv64-docker
+          path: ~/rpmbuild/RPMS/riscv64/*.rpm
+          retention-days: 7

--- a/.github/workflows/package-rpm-from-docker.yml
+++ b/.github/workflows/package-rpm-from-docker.yml
@@ -88,7 +88,7 @@ jobs:
           ls -lh ~/rpmbuild/RPMS/x86_64/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: rpm-amd64-docker
           path: /home/runner/rpmbuild/RPMS/x86_64/*.rpm
@@ -166,7 +166,7 @@ jobs:
           ls -lh ~/rpmbuild/RPMS/aarch64/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: rpm-arm64-docker
           path: /home/runner/rpmbuild/RPMS/aarch64/*.rpm
@@ -244,7 +244,7 @@ jobs:
           ls -lh ~/rpmbuild/RPMS/riscv64/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: rpm-riscv64-docker
           path: /home/runner/rpmbuild/RPMS/riscv64/*.rpm

--- a/rpm/openscad.spec
+++ b/rpm/openscad.spec
@@ -9,8 +9,6 @@ URL:            https://openscad.org/
 # Pre-built binary package - no source required
 # Binaries extracted from Docker image
 
-BuildRequires:  coreutils
-
 # Runtime dependencies for Fedora
 Requires:       qt5-qtbase
 Requires:       qt5-qtmultimedia
@@ -66,20 +64,17 @@ install -p -m 0755 %{_sourcedir}/openscad %{buildroot}%{_bindir}/openscad
 
 # Install data files if present
 if [ -d %{_sourcedir}/share ]; then
-    cp -r %{_sourcedir}/share/applications/* %{buildroot}%{_datadir}/applications/ 2>/dev/null || true
-    cp -r %{_sourcedir}/share/icons/* %{buildroot}%{_datadir}/icons/ 2>/dev/null || true
-    cp -r %{_sourcedir}/share/metainfo/* %{buildroot}%{_datadir}/metainfo/ 2>/dev/null || true
-    cp -r %{_sourcedir}/share/mime/* %{buildroot}%{_datadir}/mime/ 2>/dev/null || true
-    cp -r %{_sourcedir}/share/openscad/* %{buildroot}%{_datadir}/openscad/ 2>/dev/null || true
+    # Copy all data files with attributes preserved
+    cp -a %{_sourcedir}/share/. %{buildroot}%{_datadir}/
 fi
 
 %files
 %{_bindir}/openscad
-%{_datadir}/applications/*.desktop
+%{_datadir}/applications/openscad.desktop
 %{_datadir}/icons/hicolor/*/apps/openscad.*
-%{_datadir}/metainfo/*.xml
-%{_datadir}/mime/packages/*.xml
-%{_datadir}/openscad/
+%{_datadir}/metainfo/org.openscad.OpenSCAD.appdata.xml
+%{_datadir}/mime/packages/openscad.xml
+%dir %{_datadir}/openscad/
 
 %changelog
 * Wed Nov 19 2025 Bruno Verachten <gounthar@gmail.com> - 2025.11.19-1

--- a/rpm/openscad.spec
+++ b/rpm/openscad.spec
@@ -1,0 +1,87 @@
+Name:           openscad
+Version:        2025.11.19
+Release:        1%{?dist}
+Summary:        The Programmer's Solid 3D CAD Modeller
+
+License:        GPL-2.0-or-later
+URL:            https://openscad.org/
+
+# Pre-built binary package - no source required
+# Binaries extracted from Docker image
+
+BuildRequires:  coreutils
+
+# Runtime dependencies for Fedora
+Requires:       qt5-qtbase
+Requires:       qt5-qtmultimedia
+Requires:       qt5-qtsvg
+Requires:       CGAL
+Requires:       opencsg
+Requires:       qscintilla-qt5
+Requires:       freetype
+Requires:       fontconfig
+Requires:       harfbuzz
+Requires:       glew
+Requires:       gmp
+Requires:       mpfr
+Requires:       libzip
+Requires:       double-conversion
+Requires:       tbb
+Requires:       boost-filesystem
+Requires:       boost-regex
+Requires:       boost-system
+Requires:       lib3mf
+
+Recommends:     openscad-MCAD
+
+%description
+OpenSCAD is a software for creating solid 3D CAD objects. It focuses on CAD
+aspects rather than artistic ones.
+
+OpenSCAD is not an interactive modeller. Instead it is something like a
+3D-compiler that reads in a script file that describes the object and renders
+the 3D model from this script. This gives the designer full control over the
+modelling process and enables him to easily change any step in the modelling
+process or make designs that are defined by configurable parameters.
+
+This package contains pre-built binaries extracted from Docker images.
+
+%prep
+# No preparation needed - pre-built binaries
+
+%build
+# No build needed - pre-built binaries
+
+%install
+# Create necessary directories
+install -d %{buildroot}%{_bindir}
+install -d %{buildroot}%{_datadir}/applications
+install -d %{buildroot}%{_datadir}/icons/hicolor/scalable/apps
+install -d %{buildroot}%{_datadir}/metainfo
+install -d %{buildroot}%{_datadir}/mime/packages
+install -d %{buildroot}%{_datadir}/openscad
+
+# Install binary
+install -p -m 0755 %{_sourcedir}/openscad %{buildroot}%{_bindir}/openscad
+
+# Install data files if present
+if [ -d %{_sourcedir}/share ]; then
+    cp -r %{_sourcedir}/share/applications/* %{buildroot}%{_datadir}/applications/ 2>/dev/null || true
+    cp -r %{_sourcedir}/share/icons/* %{buildroot}%{_datadir}/icons/ 2>/dev/null || true
+    cp -r %{_sourcedir}/share/metainfo/* %{buildroot}%{_datadir}/metainfo/ 2>/dev/null || true
+    cp -r %{_sourcedir}/share/mime/* %{buildroot}%{_datadir}/mime/ 2>/dev/null || true
+    cp -r %{_sourcedir}/share/openscad/* %{buildroot}%{_datadir}/openscad/ 2>/dev/null || true
+fi
+
+%files
+%{_bindir}/openscad
+%{_datadir}/applications/*.desktop
+%{_datadir}/icons/hicolor/*/apps/openscad.*
+%{_datadir}/metainfo/*.xml
+%{_datadir}/mime/packages/*.xml
+%{_datadir}/openscad/
+
+%changelog
+* Wed Nov 19 2025 Bruno Verachten <gounthar@gmail.com> - 2025.11.19-1
+- Multi-architecture package from Docker image
+- Supports x86_64, aarch64, and riscv64 architectures

--- a/rpm/openscad.spec
+++ b/rpm/openscad.spec
@@ -39,7 +39,7 @@ aspects rather than artistic ones.
 OpenSCAD is not an interactive modeller. Instead it is something like a
 3D-compiler that reads in a script file that describes the object and renders
 the 3D model from this script. This gives the designer full control over the
-modelling process and enables him to easily change any step in the modelling
+modelling process and enables the designer to easily change any step in the modelling
 process or make designs that are defined by configurable parameters.
 
 This package contains pre-built binaries extracted from Docker images.


### PR DESCRIPTION
## Summary

- Add `rpm/openscad.spec` for packaging pre-built binaries from Docker images
- Create `package-rpm-from-docker.yml` workflow for building RPM packages
- Update `create-release.yml` to include both .deb and .rpm packages in releases
- Add Fedora/RHEL installation instructions to release notes

## Supported Architectures

- **amd64** (x86_64)
- **arm64** (aarch64)
- **riscv64**

## Workflow

1. Docker build creates images for all architectures
2. Debian packaging workflow extracts .deb packages
3. **New**: RPM packaging workflow extracts .rpm packages
4. Release workflow combines both in GitHub release

## Test plan

- [ ] Manually trigger package-rpm-from-docker.yml
- [ ] Verify RPM packages are built for all 3 architectures
- [ ] Verify release workflow includes both .deb and .rpm packages
- [ ] Test RPM installation on Fedora

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenSCAD is now distributed as RPM packages for Fedora/RHEL-family systems.
  * RPMs published for amd64, arm64 and riscv64 alongside existing DEB packages.
  * Release notes now include installation instructions for Debian/Ubuntu and Fedora/RHEL.

* **Chores**
  * Release workflow updated to assemble, count, and publish both DEB and RPM assets.
  * New automated packaging pipeline produces multi-arch RPM artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->