### PR TITLE
feat: skip daily builds when upstream hasn't changed

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -282,6 +282,16 @@ jobs:
           - RPM packages from run: ${{ steps.runs.outputs.rpm_run_id }}
           EOF
 
+          # Extract and append OPENSCAD_COMMIT from Dockerfile for change detection
+          OPENSCAD_COMMIT=$(grep "ARG OPENSCAD_COMMIT=" docker/Dockerfile | sed 's/ARG OPENSCAD_COMMIT=//')
+          cat >> release-notes.md << EOF
+
+          ### Upstream OpenSCAD
+          - **OPENSCAD_COMMIT=${OPENSCAD_COMMIT}**
+          - Upstream repository: https://github.com/openscad/openscad
+          - Commit details: https://github.com/openscad/openscad/commit/${OPENSCAD_COMMIT}
+          EOF
+
           # Create release without assets first
           if [ "${PRERELEASE}" = "true" ]; then
             gh release create "${{ steps.version.outputs.tag }}" \

--- a/.github/workflows/docker-build-matrix.yml
+++ b/.github/workflows/docker-build-matrix.yml
@@ -54,6 +54,25 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Log change detection result
+        run: |
+          echo "## 🔍 Change Detection Result" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Current commit:** \`${{ steps.check.outputs.current_commit }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Last release commit:** \`${{ steps.check.outputs.last_commit }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.check.outputs.should_build }}" = "true" ]; then
+            echo "**Decision:** ✅ **Build will proceed** - upstream has changes" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "[View commit diff](https://github.com/openscad/openscad/compare/${{ steps.check.outputs.last_commit }}...${{ steps.check.outputs.current_commit }})" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**Decision:** ⏭️ **Build skipped** - no upstream changes detected" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "_The upstream OpenSCAD commit hasn't changed since the last release._" >> $GITHUB_STEP_SUMMARY
+            echo "_Next check: tomorrow at 2 AM UTC_" >> $GITHUB_STEP_SUMMARY
+          fi
+
   # Build each architecture in parallel
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-matrix.yml
+++ b/.github/workflows/docker-build-matrix.yml
@@ -17,9 +17,50 @@ env:
   VERSION: latest
 
 jobs:
+  # Check if upstream commit has changed since last release
+  check-changes:
+    runs-on: ubuntu-latest
+    # Only run change detection for scheduled builds
+    # Push and PR events should always build
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+      current_commit: ${{ steps.check.outputs.current_commit }}
+      last_commit: ${{ steps.check.outputs.last_commit }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Check if upstream changed
+        id: check
+        run: |
+          # Extract current commit from Dockerfile
+          CURRENT_COMMIT=$(grep "ARG OPENSCAD_COMMIT=" docker/Dockerfile | sed 's/ARG OPENSCAD_COMMIT=//')
+          echo "current_commit=${CURRENT_COMMIT}" >> $GITHUB_OUTPUT
+          echo "Current upstream commit: ${CURRENT_COMMIT}"
+
+          # Get commit from last release (if exists)
+          LAST_COMMIT=$(gh release view --json body --jq '.body' 2>/dev/null | grep -oP 'OPENSCAD_COMMIT=\K[a-fA-F0-9]{40}' | head -1 || echo "none")
+          echo "last_commit=${LAST_COMMIT}" >> $GITHUB_OUTPUT
+          echo "Last release commit: ${LAST_COMMIT}"
+
+          if [ "$CURRENT_COMMIT" = "$LAST_COMMIT" ]; then
+            echo "✅ No upstream changes since last release - skipping build"
+            echo "should_build=false" >> $GITHUB_OUTPUT
+          else
+            echo "🔄 Upstream changed: ${LAST_COMMIT} -> ${CURRENT_COMMIT}"
+            echo "should_build=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   # Build each architecture in parallel
   build:
     runs-on: ubuntu-latest
+    needs: check-changes
+    # Skip if change detection ran and found no changes
+    # Always run for push/PR events (when check-changes is skipped)
+    if: always() && (needs.check-changes.result == 'skipped' || needs.check-changes.outputs.should_build == 'true')
     strategy:
       fail-fast: false  # Continue other builds even if one fails
       matrix:


### PR DESCRIPTION
## Summary

Implements intelligent change detection to prevent unnecessary daily builds when the upstream OpenSCAD commit hasn't changed since the last release.

Fixes #57

## Problem

With the daily schedule from PR #56, the workflow would create **365 releases per year**, but upstream OpenSCAD only has ~10-20 commits per year. This wastes:
- CI/CD resources (expensive multi-arch Docker builds)
- Storage (duplicate artifacts)  
- Bandwidth (package repositories)
- User attention (meaningless "new" releases)

## Solution

### 1. Change Detection Job (`docker-build-matrix.yml`)

Added `check-changes` job that runs before builds:

```yaml
check-changes:
  # Only for scheduled/manual builds
  if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
  steps:
    - Extract OPENSCAD_COMMIT from docker/Dockerfile
    - Get commit from last release notes
    - Compare: skip if unchanged, build if different
    - Output: should_build, current_commit, last_commit
```

The `build` job now depends on `check-changes`:
```yaml
build:
  needs: check-changes
  # Skip if no changes, always run for push/PR
  if: always() && (needs.check-changes.result == 'skipped' || needs.check-changes.outputs.should_build == 'true')
```

### 2. Release Notes Enhancement (`create-release.yml`)

Releases now include upstream commit information:

```markdown
### Upstream OpenSCAD
- **OPENSCAD_COMMIT=63150dbbae53b2c8dbd75143a57409e60c1eb404**
- Upstream repository: https://github.com/openscad/openscad
- Commit details: https://github.com/openscad/openscad/commit/63150dbba...
```

This enables future change detection by providing a reliable source for the last built commit.

## Behavior Matrix

| Trigger Type | Change Detection | Behavior |
|--------------|------------------|----------|
| **Schedule** (2 AM UTC) | ✅ Runs | Skip if unchanged, build if changed |
| **Push** to multiplatform | ❌ Skipped | Always build (fork code changes) |
| **Pull Request** | ❌ Skipped | Always build (for testing) |
| **Manual Dispatch** | ✅ Runs | Skip if unchanged, build if changed |

## Impact

**Before (with PR #56):**
- 365 builds/releases per year
- ~345 are duplicates (94-97%)
- Massive resource waste

**After (with this PR):**
- Only 10-20 builds/releases per year (when upstream changes)
- 95%+ reduction in unnecessary builds
- Cleaner release history
- Meaningful version numbers

## Example Logs

**When skipping (no changes):**
```
✅ No upstream changes since last release - skipping build
Current upstream commit: 63150dbbae53b2c8dbd75143a57409e60c1eb404
Last release commit: 63150dbbae53b2c8dbd75143a57409e60c1eb404
```

**When building (changes detected):**
```
🔄 Upstream changed: 63150dbba -> 6d8ff0587
Current upstream commit: 6d8ff0587
Last release commit: 63150dbba
```

## Testing Checklist

- [ ] Scheduled build skips when commit unchanged
- [ ] Scheduled build runs when commit changes
- [ ] Push events always build (regardless of upstream)
- [ ] PR events always build (regardless of upstream)
- [ ] Release notes include OPENSCAD_COMMIT
- [ ] Change detection finds commit in release notes
- [ ] Manual dispatch respects change detection

## Related

- Fixes #57 (Prevent unnecessary daily releases)
- Builds on PR #56 (Daily builds and upstream sync)
- Works with UpdateCLI (detects upstream changes daily at 6 AM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Release notes now include upstream OpenSCAD commit information, repository links, and a commit details section for easier traceability.

* **Chores**
  * Build pipeline now detects upstream changes and skips unnecessary builds when no updates are present, while preserving multi-platform builds when changes are detected or checks are skipped.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->