### PR TITLE
Fix GitHub Pages deployment by pruning old packages

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -127,7 +127,7 @@ jobs:
             if [ "$COUNT" -gt "$KEEP" ]; then
               REMOVE_COUNT=$((COUNT - KEEP))
               echo "Pruning ${REMOVE_COUNT} old ${ARCH} packages (keeping latest ${KEEP})..."
-              echo "$PKGS" | head -n "$REMOVE_COUNT" | while read pkg; do
+              echo "$PKGS" | head -n "$REMOVE_COUNT" | while IFS= read -r pkg; do
                 echo "  Removing: $(basename "$pkg")"
                 rm -f "$pkg"
               done
@@ -138,8 +138,8 @@ jobs:
 
           echo ""
           echo "Packages after pruning:"
-          ls -1 "${POOL}"/*.deb | wc -l
-          ls -lh "${POOL}"/*.deb
+          ls -1 "${POOL}"/*.deb 2>/dev/null | wc -l || true
+          ls -lh "${POOL}"/*.deb 2>/dev/null || true
 
       - name: Generate Packages files for each architecture
         if: steps.check_artifacts.outputs.has_artifacts == 'true'
@@ -320,7 +320,7 @@ jobs:
 
                   # Restore our changes
                   cp -a "$TEMP_DIR"/debian-* downloads/ 2>/dev/null || true
-                  cp -a "$TEMP_DIR"/pool . 2>/dev/null || true
+                  rm -rf pool && cp -a "$TEMP_DIR"/pool . 2>/dev/null || true
                   cp -a "$TEMP_DIR"/dists . 2>/dev/null || true
                   cp -a "$TEMP_DIR"/debian . 2>/dev/null || true
                   cp -a "$TEMP_DIR"/index.html . 2>/dev/null || true

--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -113,6 +113,34 @@ jobs:
           echo "Packages in pool:"
           ls -lh pool/${{ env.COMPONENT }}/
 
+      - name: Prune old packages (keep latest 3 per arch)
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
+        run: |
+          KEEP=3
+          POOL="pool/${{ env.COMPONENT }}"
+
+          for ARCH in amd64 arm64 riscv64; do
+            # List packages for this arch sorted by version (oldest first)
+            PKGS=$(ls -1 "${POOL}"/openscad_*_${ARCH}.deb 2>/dev/null | sort -V)
+            COUNT=$(echo "$PKGS" | grep -c . || true)
+
+            if [ "$COUNT" -gt "$KEEP" ]; then
+              REMOVE_COUNT=$((COUNT - KEEP))
+              echo "Pruning ${REMOVE_COUNT} old ${ARCH} packages (keeping latest ${KEEP})..."
+              echo "$PKGS" | head -n "$REMOVE_COUNT" | while read pkg; do
+                echo "  Removing: $(basename "$pkg")"
+                rm -f "$pkg"
+              done
+            else
+              echo "${ARCH}: ${COUNT} packages, nothing to prune"
+            fi
+          done
+
+          echo ""
+          echo "Packages after pruning:"
+          ls -1 "${POOL}"/*.deb | wc -l
+          ls -lh "${POOL}"/*.deb
+
       - name: Generate Packages files for each architecture
         if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |

--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -145,6 +145,44 @@ jobs:
             fi
           done
 
+      - name: Prune old packages (keep latest 3 per arch)
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
+        run: |
+          KEEP=3
+
+          for arch in x86_64 aarch64 riscv64; do
+            ARCH_DIR="rpm/fedora/${arch}"
+
+            # Skip if no packages exist
+            if ! ls "${ARCH_DIR}"/*.rpm 1>/dev/null 2>&1; then
+              continue
+            fi
+
+            # List packages sorted by version (oldest first)
+            PKGS=$(ls -1 "${ARCH_DIR}"/openscad-*.rpm 2>/dev/null | sort -V)
+            COUNT=$(echo "$PKGS" | grep -c . || true)
+
+            if [ "$COUNT" -gt "$KEEP" ]; then
+              REMOVE_COUNT=$((COUNT - KEEP))
+              echo "Pruning ${REMOVE_COUNT} old ${arch} RPMs (keeping latest ${KEEP})..."
+              echo "$PKGS" | head -n "$REMOVE_COUNT" | while read pkg; do
+                echo "  Removing: $(basename "$pkg")"
+                rm -f "$pkg"
+              done
+            else
+              echo "${arch}: ${COUNT} packages, nothing to prune"
+            fi
+          done
+
+          echo ""
+          echo "Packages after pruning:"
+          for arch in x86_64 aarch64 riscv64; do
+            if ls rpm/fedora/${arch}/*.rpm 1>/dev/null 2>&1; then
+              PKG_COUNT=$(ls -1 rpm/fedora/${arch}/*.rpm | wc -l)
+              echo "  ${arch}: ${PKG_COUNT} packages"
+            fi
+          done
+
       - name: Generate repository metadata for each architecture
         if: steps.check_artifacts.outputs.has_artifacts == 'true'
         run: |
@@ -159,17 +197,12 @@ jobs:
 
             echo "Creating repository metadata for ${arch}..."
 
-            # Create or update repository metadata
-            if [ -d "${ARCH_DIR}/repodata" ]; then
-              if ! createrepo_c --update "${ARCH_DIR}"; then
-                echo "Error: Failed to update repository metadata for ${arch}"
-                exit 1
-              fi
-            else
-              if ! createrepo_c "${ARCH_DIR}"; then
-                echo "Error: Failed to create repository metadata for ${arch}"
-                exit 1
-              fi
+            # Remove old repodata and recreate from scratch
+            # (required after pruning old packages)
+            rm -rf "${ARCH_DIR}/repodata"
+            if ! createrepo_c "${ARCH_DIR}"; then
+              echo "Error: Failed to create repository metadata for ${arch}"
+              exit 1
             fi
 
             # Count packages

--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -154,7 +154,7 @@ jobs:
             ARCH_DIR="rpm/fedora/${arch}"
 
             # Skip if no packages exist
-            if ! ls "${ARCH_DIR}"/*.rpm 1>/dev/null 2>&1; then
+            if ! ls "${ARCH_DIR}"/openscad-*.rpm 1>/dev/null 2>&1; then
               continue
             fi
 
@@ -165,7 +165,7 @@ jobs:
             if [ "$COUNT" -gt "$KEEP" ]; then
               REMOVE_COUNT=$((COUNT - KEEP))
               echo "Pruning ${REMOVE_COUNT} old ${arch} RPMs (keeping latest ${KEEP})..."
-              echo "$PKGS" | head -n "$REMOVE_COUNT" | while read pkg; do
+              echo "$PKGS" | head -n "$REMOVE_COUNT" | while IFS= read -r pkg; do
                 echo "  Removing: $(basename "$pkg")"
                 rm -f "$pkg"
               done
@@ -407,7 +407,7 @@ jobs:
 
                   # Restore our changes
                   cp -a "$TEMP_DIR"/rpm-* downloads/ 2>/dev/null || true
-                  cp -a "$TEMP_DIR"/rpm . 2>/dev/null || true
+                  rm -rf rpm && cp -a "$TEMP_DIR"/rpm . 2>/dev/null || true
                   cp -a "$TEMP_DIR"/index.html . 2>/dev/null || true
                   rm -rf "$TEMP_DIR"
 


### PR DESCRIPTION
## Summary

- GitHub Pages deployment fails because `gh-pages` branch is 10.4 GB (1 GB limit)
- 115 deb versions and 107 rpm versions per architecture have accumulated over time
- Add pruning step to both APT and RPM repo update workflows: keep only the latest 3 versions per architecture, remove older packages before regenerating metadata
- Force fresh `createrepo_c` rebuild (instead of `--update`) after pruning to keep metadata consistent

Fixes the failing deployment: https://github.com/gounthar/openscad/actions/runs/22336397087

## Estimated size after pruning

| Content | Before | After |
|---------|--------|-------|
| pool/ (debs) | 4.1 GB (345 files) | ~105 MB (9 files) |
| rpm/ (rpms) | 6.5 GB (321 files) | ~160 MB (9 files) |
| repodata/ | 33 MB (1356 files) | ~1 MB (9 files) |
| downloads/ | 96 MB | 96 MB |
| **Total** | **10.4 GB** | **~400 MB** |

## Test plan

- [ ] Merge PR, then trigger `update-apt-repo.yml` manually (workflow_dispatch)
- [ ] Verify pruning step logs show old packages removed
- [ ] Verify Pages deployment succeeds (under 1 GB)
- [ ] Verify `apt-get install openscad` still works from the repo
- [ ] Trigger `update-rpm-repo.yml` manually and verify same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automatically prune old packages, keeping only the latest 3 versions per architecture for both DEB and RPM repositories.
  * Always rebuild repository metadata after pruning for consistent package indices.
  * Ensure prior repository data is cleaned before restoring backups to avoid leftover state.
  * Improved logging to report pruning actions and post-prune package counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->